### PR TITLE
Fix JSON parsing and logging in SynonymAPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,11 @@
 	  <artifactId>junit</artifactId>
 	  <version>4.12</version>
 	</dependency>
+	<!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
 	<dependency>
-	    <groupId>com.codesnippets4all</groupId>
-	    <artifactId>quick-json</artifactId>
-	    <version>1.0.4</version>
+	    <groupId>com.googlecode.json-simple</groupId>
+	    <artifactId>json-simple</artifactId>
+	    <version>1.1.1</version>
 	</dependency>
   </dependencies>
 </project>

--- a/src/model/SynonymAPI.java
+++ b/src/model/SynonymAPI.java
@@ -8,12 +8,16 @@ import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import com.codesnippets4all.json.parsers.JSONParser;
-import com.codesnippets4all.json.parsers.JsonParserFactory;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 public class SynonymAPI {
+	private static final Logger LOGGER = Logger.getLogger(WordPrompt.class.getName());
 	
 	public List<String> getSynonyms(String word) {
 		URL datamuse;
@@ -37,13 +41,16 @@ public class SynonymAPI {
 	public List<String> synonymArray(String synStr) {
 		List<String> synonyms = new ArrayList<>();
 		
-		JsonParserFactory factory=JsonParserFactory.getInstance();
-        JSONParser parser=factory.newJsonParser();
-        Map jsonData=parser.parseJson(synStr);
-        List al= (List) jsonData.get("root");
-        for (int i = 0; i < al.size(); i++) {
-        	synonyms.add((String) ((Map)al.get(i)).get("word"));
-        }
+        JSONParser parser = new JSONParser();
+        JSONArray jsonData;
+		try {
+			jsonData = (JSONArray)(parser.parse(synStr));
+	        for (Object element : jsonData) {
+	        	synonyms.add((String) ((JSONObject)element).get("word"));
+	        }
+		} catch (ParseException e) {
+			LOGGER.log(Level.WARNING, "Could not parse JSONArray.");
+		}
         return synonyms;
 	}
 	

--- a/src/test/WordPromptTest.java
+++ b/src/test/WordPromptTest.java
@@ -50,7 +50,8 @@ public class WordPromptTest {
 		String word = prompt.getWord(level);
 		
 		List<String> synonyms = api.getSynonyms("beautiful");
-		assertTrue(word.length() <= 4);
+		assertTrue(word.length() > 4);
+		assertTrue(word.length() <= 7);
 		assertTrue(synonyms.contains("pretty"));
 	}
 	
@@ -63,7 +64,7 @@ public class WordPromptTest {
 		String word = prompt.getWord(level);
 		
 		List<String> synonyms = api.getSynonyms("mischievous");
-		assertTrue(word.length() <= 4);
+		assertTrue(word.length() > 7);
 		assertTrue(synonyms.contains("bad"));
 	}
 


### PR DESCRIPTION
Use simple json for the SynonymAPI instead of the weird one that I was using last time.